### PR TITLE
Set flag to check_output to return more readable output.

### DIFF
--- a/conductor/step.py
+++ b/conductor/step.py
@@ -53,7 +53,8 @@ class Step():
         else:
             try:
                 output = subprocess.check_output(self.args,
-                                                 timeout=self.timeout)
+                                                 timeout=self.timeout,
+                                                 universal_newlines=True)
             except subprocess.CalledProcessError as err:
                 print ("Code: ", err.returncode, "Command: ", err.cmd,
                        "Output: ", err.output)


### PR DESCRIPTION
The output of commands that are run during test runs with conductor is a lot easier to read with universal_newlines=True added to the arguments of check_output.
