### PR TITLE
Fix setup.py to work by reading README.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     keywords = "networking testing",
     url = "http://packages.python.org/",
     packages=['conductor'],
-    long_description=read('README'),
+    long_description=read('README.md'),
     classifiers=[
         "Development Status :: 1 - Alpha",
         "Topic :: Utilities",


### PR DESCRIPTION
Else setup.py bails with:

`sbruno@sysdev03:~/conductor % sudo python3 ./setup.py install                                                                                                                                   
Traceback (most recent call last):
  File "./setup.py", line 55, in <module>
    long_description=read('README'),
  File "./setup.py", line 43, in read
    return open(os.path.join(os.path.dirname(__file__), fname)).read()
FileNotFoundError: [Errno 2] No such file or directory: './README'
`